### PR TITLE
Support graphql-ruby 1.10.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# 1.2.0
+Provides support for graphql-ruby 1.10.x
+
 #0.6.0
 Updates Canvas API definitions
 

--- a/lib/lms_graphql/types/date_time_type.rb
+++ b/lib/lms_graphql/types/date_time_type.rb
@@ -1,7 +1,7 @@
 module LMSGraphQL
   module Types
     class DateTimeType < ::GraphQL::Schema::Scalar
-      name "DateTime"
+      graphql_name "DateTime"
 
       def self.coerce_input(value, _ctx)
         Time.zone.parse(value)

--- a/lib/lms_graphql/types/date_time_type.rb
+++ b/lib/lms_graphql/types/date_time_type.rb
@@ -1,15 +1,18 @@
 module LMSGraphQL
   module Types
-    DateTimeType = ::GraphQL::ScalarType.define do
+    class DateTimeType < ::GraphQL::Schema::Scalar
       name "DateTime"
 
-      coerce_input ->(value, _ctx) { Time.zone.parse(value) }
-      coerce_result ->(value, _ctx) {
+      def self.coerce_input(value, _ctx)
+        Time.zone.parse(value)
+      end
+
+      def self.coerce_result(value, _ctx)
         if value.is_a? String
           value = Time.zone.parse(value)
         end
         value.utc.iso8601
-      }
+      end
     end
   end
 end


### PR DESCRIPTION
This makes a couple of changes necessary for compatibility with `graphql-ruby` 1.10.x.

References are given in the commit messages.

I tested this in Socialize and Atomic Assessments and things looked good. I didn't test it in any other projects.