### PR TITLE
Handle nil values

### DIFF
--- a/lib/lms_graphql/types/date_time_type.rb
+++ b/lib/lms_graphql/types/date_time_type.rb
@@ -4,10 +4,14 @@ module LMSGraphQL
       graphql_name "DateTime"
 
       def self.coerce_input(value, _ctx)
+        return if !value
+
         Time.zone.parse(value)
       end
 
       def self.coerce_result(value, _ctx)
+        return if !value
+
         if value.is_a? String
           value = Time.zone.parse(value)
         end


### PR DESCRIPTION
Graphql 1.10 now calls .coerce_input on all input values - previously
this call was skipped for null values.